### PR TITLE
Add build badge and gradle task for uploading to Bintray/JCenter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,12 @@ EtherJar
 
 Lightweight Java client to Ethereum blockchain
 
+http://ec2-54-81-112-125.compute-1.amazonaws.com/Etherjar_Master[Build Status]
+
+.Image caption
+image::http://ec2-54-81-112-125.compute-1.amazonaws.com/Etherjar_Master/status.png[Build Status]
+
+
 ## Features
 
 TODO

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Lightweight Java client to Ethereum blockchain
 
 http://ec2-54-81-112-125.compute-1.amazonaws.com/Etherjar_Master[Build Status]
 
-.Image caption
+.Image
 image::http://ec2-54-81-112-125.compute-1.amazonaws.com/Etherjar_Master/status.png[Build Status]
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'org.ethereumclassic'
-version = '0.1'
+version = '0.1-SNAPSHOT'
 def description = 'Lightweight Java client to Ethereum blockchain'
 
 targetCompatibility = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,15 @@
+plugins {
+    id "com.jfrog.bintray" version "1.7"
+}
+
 apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 group = 'org.ethereumclassic'
-version = '0.1-SNAPSHOT'
+version = '0.1'
+def description = 'Lightweight Java client to Ethereum blockchain'
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
@@ -11,8 +17,8 @@ sourceCompatibility = '1.7'
 repositories {
     mavenLocal()
     mavenCentral()
+    jcenter()
 }
-
 
 dependencies {
 
@@ -26,3 +32,40 @@ dependencies {
     testCompile "org.spockframework:spock-core:$spockVersion"
 
 }
+
+publishing {
+    publications {
+        EtherJarPublication(MavenPublication) {
+            from components.java
+            artifact sourceJar
+            pom.withXml {
+                asNode().appendNode('description', description)
+            }
+        }
+    }
+}
+
+task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier "sources"
+}
+
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+    publications = ['EtherJarPublication']
+    pkg {
+        repo = 'EtherJar'
+        name = 'etherjar'
+        userOrg = 'ethereumproject'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/ethereumproject/etherjar.git'
+        labels = ['etherjar', 'etc']
+        publicDownloadNumbers = true
+        version {
+            name = project.version
+            description = project.description
+        }
+    }
+}
+


### PR DESCRIPTION
the new task is invoked as
gradle bintrayUpload

it relies on the BINTRAY_API_KEY and BINTRAY_USER being exported into the environment or having been set in settings.gradle. These keys are assigned with a Bintray user account and membership in Bintray integration with the Ethereumproject organization. 

JCenter doesn't support -SNAPSHOT deployments (at least not for free users) so this task is not integrated into TeamCity builds.

